### PR TITLE
Remove history.tsv from the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+!/csv/history.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-!/csv/history.tsv
+/csv/history.tsv

--- a/csv/history.tsv
+++ b/csv/history.tsv
@@ -1,1 +1,0 @@
-model_A	model_A_hash	model_B	model_B_hash	model_O	model_O_hash	base_alpha	weight_name	weight_values

--- a/scripts/merge_history.py
+++ b/scripts/merge_history.py
@@ -32,8 +32,8 @@ class MergeHistory():
 
         if not os.path.exists(self.filepath):
             with open(self.filepath, "w", newline="", encoding="utf-8") as f:
-                wr = writer(f, fieldnames=HEADERS, delimiter='\t')
-                wr.writerow(HEADERS)
+                wr = DictWriter(f, fieldnames=HEADERS, delimiter='\t')
+                wr.writeheader()
         # save to file
         with open(self.filepath, "a", newline="", encoding='utf-8') as f:
             dictwriter = DictWriter(f, fieldnames=HEADERS, delimiter='\t')


### PR DESCRIPTION
History.tsv was removed because its presence in the repository could cause history.tsv in the local environment to be overwritten when updating.